### PR TITLE
Add three new BDR Registers (vocabs) from the bdr-vocabs repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = sources/dawe-rlp-vocabs
 	url = https://github.com/ternaustralia/dawe-rlp-vocabs.git
 	branch = main
+[submodule "sources/bdr-vocabs"]
+	path = sources/bdr-vocabs
+	url = https://github.com/dcceew-bdr/bdr-vocabs.git
+	branch = main

--- a/config.toml
+++ b/config.toml
@@ -49,7 +49,7 @@ include_concept_schemes = ["http://linked.data.gov.au/dataset/bioregion/IBRA7"]
 [[catalogs]]
 token = "abis"
 label = "ABIS Vocabularies"
-source = ""  # No Source, each ABIS Vocabulary has its owl file
+source = ""  # No Catalog-level source, each ABIS Vocabulary has its own source file
 
 [[catalogs.vocabularies]] # ABIS Vocab Themes vocabulary.
 name = "abis-themes"
@@ -78,6 +78,40 @@ root_node = "https://linked.data.gov.au/def/data-roles" # Concept Scheme
 source = "https://agldwg.github.io/data-roles/vocabulary.ttl"
 
 
+## BDR Vocabularies and Registers
+[[catalogs]]
+token = "bdr-cv"
+label = "BDR Vocabularies and Registers"
+source = ""  # No Source, each BDR Vocab/Register has its own source file
+
+[[catalogs.vocabularies]] # BDR Observable Properties Register (Vocab)
+name = "bdr-observable-properties"
+keywords = ["properties", "observable properties", "obsprops", "bdr"]
+themes = ["https://linked.data.gov.au/def/abis/vocab-themes/observable-properties"]
+vann_prefix = "bdr-obsprops"
+vann_namespace = "https://linked.data.gov.au/dataset/bdr/obsprops/"
+root_node = "https://linked.data.gov.au/dataset/bdr/obsprops" # Concept Scheme
+source = "file://./sources/bdr-vocabs/vocabs/observable-properties.ttl"
+
+[[catalogs.vocabularies]] # BDR Data Types Register (Vocab)
+name = "bdr-datatypes"
+keywords = ["data", "datatype", "types", "bdr"]
+themes = ["https://linked.data.gov.au/def/abis/vocab-themes/datatypes"]
+vann_prefix = "bdr-datatypes"
+vann_namespace = "https://linked.data.gov.au/dataset/bdr/datatypes/"
+root_node = "https://linked.data.gov.au/dataset/bdr/datatypes" # Concept Scheme
+source = "file://./sources/bdr-vocabs/vocabs/datatypes.ttl"
+
+[[catalogs.vocabularies]] # BDR Submitting Organisations Register (Vocab)
+name = "bdr-orgs"
+keywords = ["submitting", "organisations", "organizations", "orgs", "bdr"]
+themes = []
+vann_prefix = "bdr-orgs"
+vann_namespace = "https://linked.data.gov.au/dataset/bdr/orgs/"
+root_node = "https://linked.data.gov.au/dataset/bdr/orgs" # Concept Scheme
+source = "file://./sources/bdr-vocabs/vocabs/submitting-organisations.ttl"
+
+
 [extra_keywords_mappings]
 # Manually map ConceptScheme IDs or Collection IDs to extra keywords
 "http://linked.data.gov.au/def/tern-cv/dd085299-ae86-4371-ae15-61dfa432f924" = ["attributes"]  # Attributes ConceptScheme
@@ -86,5 +120,5 @@ source = "https://agldwg.github.io/data-roles/vocabulary.ttl"
 "http://linked.data.gov.au/def/tern-cv/68af3d25-c801-4089-afff-cf701e2bd61d" = ["feature", "type"] # Feature Type ConceptScheme
 
 [extra_themes_mappings]
-# Manually map ConceptScheme IDs to extra ABIS Vocab themes
+# Manually map ConceptScheme IDs to extra ABIS Vocab-Themes
 "http://linked.data.gov.au/def/tern-cv/68af3d25-c801-4089-afff-cf701e2bd61d" = ["https://linked.data.gov.au/def/abis/vocab-themes/feature-types"]

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -1,3 +1,5 @@
+
+
 if __name__ == '__main__':
     import sys
     print("Run with python main.py or python -m src")
@@ -5,10 +7,9 @@ if __name__ == '__main__':
 
 from . import config
 from .catalog import build_catalog
-
+from .voc_graph import make_voc_graph
 
 async def build_catalogs():
-
     catalog_defs = config.get_value("catalogs", None)
     if catalog_defs is None or len(catalog_defs) == 0:
         raise Exception("No catalogs defined")
@@ -17,8 +18,16 @@ async def build_catalogs():
         if 'token' not in catalog_def:
             raise RuntimeError("Catalog entry does not have name property.")
         print(f"building {catalog_def['token']}")
-        catalog_g = await build_catalog(catalog_def)
-
+        cat_details = await build_catalog(catalog_def)
+        cat_ds = make_voc_graph(multigraph=True)
+        cat_uri = cat_details.cat_uri
+        for (s, p, o) in cat_details.graph:
+            cat_ds.add((s, p, o, cat_uri))
+        for content_graph in cat_details.content_graphs:
+            for (s, p, o) in content_graph.graph:
+                cat_ds.add((s, p, o, cat_uri))
+        with open(f"./generated/{catalog_def['token']}/all.nq", "wb") as f:
+            cat_ds.serialize(f, format="nquads")
 
 def entrypoint() -> int:
     import asyncio

--- a/src/voc_graph.py
+++ b/src/voc_graph.py
@@ -8,16 +8,25 @@ TERN = rdflib.Namespace("https://w3id.org/tern/ontologies/tern/")
 ABIS = rdflib.Namespace("https://linked.data.gov.au/def/abis/")
 BDR = rdflib.Namespace("https://linked.data.gov.au/dataset/bdr/")
 
+
 @dataclass
 class VocabGraphDetails:
     graph: rdflib.Graph
     keywords: List[str]
     themes: List[rdflib.URIRef]
     token: str
-    vocab_uri: rdflib.URIRef  # This is the ConceptScheme
+    vocab_uri: rdflib.URIRef  # This is the SKOS:ConceptScheme
 
 
-def make_voc_graph():
+@dataclass
+class CatalogGraphDetails:
+    graph: rdflib.Graph
+    token: str
+    cat_uri: rdflib.URIRef  # This is the DCAT:Catalog
+    content_graphs: List[VocabGraphDetails]
+
+
+def make_voc_graph(multigraph: bool = False):
     g = rdflib.Graph(bind_namespaces="core")
     ns = g.namespace_manager
     ns.bind("skos", SKOS)
@@ -29,4 +38,8 @@ def make_voc_graph():
     ns.bind("schema", SDO)
     ns.bind("abis", ABIS)
     ns.bind("bdr", BDR)
+    if multigraph:
+        ds = rdflib.Dataset(store=g.store)
+        ds.namespace_manager = ns
+        return ds
     return g


### PR DESCRIPTION
1) Add bdr-vocabs repo as submodule in this repo under `sources/` (to be kept in sync)
2) Added a new catalog definition for BDR-managed registers and vocabs (called bdr-cv)
3) Add each of the three new Registers as entries under the bdr-cv catalog, with relative links to their source file in the subrepo
4) Add ABIS-Themes for each vocab, and keywords to annotate the entry in the catalog.
