### PR TITLE
Catalogue updates

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@
 # https://linked.data.gov.au/dataset/bdr/catalogs/<token>
 # So the graph_name set below cannot be the same as the VirtualGraph name
 token = "tern-cv"
-label = "TERN Controlled Vocabularies"
+label = "TERN Vocabularies"
 source = "sparql:https://graphdb.tern.org.au/repositories/tern_vocabs_core"
 # This is the identifier of the named-graph (RG) this catalog gets loaded into
 graph_name = "https://linked.data.gov.au/dataset/bdr/catalogs/tern-cv-rg"
@@ -27,7 +27,7 @@ graph_name = "https://linked.data.gov.au/dataset/bdr/catalogs/tern-cv-rg"
 # NRM/EMSA/DAWE Vocabularies, hosted in TERN's GraphDB instance
 [[catalogs]]
 token = "nrm"
-label = "Ecological Monitoring System Australia (EMSA) Controlled Vocabularies"
+label = "EMSA Vocabularies"
 source = "sparql:https://graphdb.tern.org.au/repositories/dawe_vocabs_core"
 # This is the identifier of the named-graph (RG) this catalog gets loaded into
 graph_name = "https://linked.data.gov.au/dataset/bdr/catalogs/nrm-cv-rg"
@@ -56,7 +56,7 @@ include_concept_schemes = ["http://linked.data.gov.au/dataset/bioregion/IBRA7"]
 name = "alum"
 token = "alum"
 source = "sparql:http://vocabs.ardc.edu.au/repository/api/sparql/abares_australian-land-use-and-management-classification_version-8-with-pids"
-label = "Australian Land Use and Management Classification"
+label = "ALUM Vocabularies"
 
 [[catalogs.vocabularies]]
 name = "alum"
@@ -103,7 +103,7 @@ source = "https://agldwg.github.io/data-roles/vocabulary.ttl"
 ## BDR Vocabularies and Registers
 [[catalogs]]
 token = "bdr-cv"
-label = "BDR Vocabularies and Registers"
+label = "BDR-Defined Vocabularies"
 source = ""  # No Source, each BDR Vocab/Register has its own source file
 
 [[catalogs.vocabularies]] # BDR Observable Properties Register (Vocab)
@@ -159,7 +159,7 @@ vann_namespace = "https://linked.data.gov.au/dataset/bdr/"
 
 [[catalogs]]
 token = "asls"
-label = "Australian Soil and Landscape Survey Field Handbook"
+label = "ASLS Vocabularies"
 source = ""
 
 [[catalogs.vocabularies]]

--- a/config.toml
+++ b/config.toml
@@ -51,7 +51,7 @@ vann_namespace = "http://linked.data.gov.au/dataset/bioregion/"
 include_concept_schemes = ["http://linked.data.gov.au/dataset/bioregion/IBRA7"]
 
 
-## ACLUMP was moved to Linked.data.gov.au
+## ACLUMP was moved to linked.data.gov.au
 [[catalogs]]
 name = "alum"
 token = "alum"
@@ -83,27 +83,10 @@ root_node = "https://linked.data.gov.au/def/abis/vocab-themes" # Concept Scheme
 source = "file:./sources/abis-themes.ttl"
 
 
-## AGLDWG Data Roles
-[[catalogs]]
-token = "data-roles"
-label = "Data Roles"
-source = ""  # No Catalog-level Source, vocab is its own file
-
-[[catalogs.vocabularies]] # AGLDWG Data Roles Vocabulary
-name = "data-roles"
-keywords = ["data", "roles", "agldwg"]
-themes = ["https://linked.data.gov.au/def/abis/vocab-themes/data-roles"]
-vann_prefix = "data-roles"
-vann_namespace = "https://linked.data.gov.au/def/data-roles/"
-root_node = "https://linked.data.gov.au/def/data-roles" # Concept Scheme
-# This is an example of a HTTPS source, loaded from the web
-source = "https://agldwg.github.io/data-roles/vocabulary.ttl"
-
-
-## BDR Vocabularies and Registers
+## BDR Vocabularies
 [[catalogs]]
 token = "bdr-cv"
-label = "BDR-Defined Vocabularies"
+label = "BDR Vocabularies"
 source = ""  # No Source, each BDR Vocab/Register has its own source file
 
 [[catalogs.vocabularies]] # BDR Observable Properties Register (Vocab)
@@ -150,6 +133,17 @@ vann_prefix = "bdr-sma"
 vann_namespace = "https://linked.data.gov.au/dataset/bdr/sma/"
 root_node = "https://linked.data.gov.au/dataset/bdr/sma" # Concept Scheme
 source = "file:./sources/bdr-vocabs/vocabs/sma.ttl"
+
+[[catalogs.vocabularies]] # AGLDWG Data Roles Vocabulary
+name = "data-roles"
+keywords = ["data", "roles", "agldwg"]
+themes = ["https://linked.data.gov.au/def/abis/vocab-themes/data-roles"]
+vann_prefix = "data-roles"
+vann_namespace = "https://linked.data.gov.au/def/data-roles/"
+root_node = "https://linked.data.gov.au/def/data-roles" # Concept Scheme
+# This is an example of a HTTPS source, loaded from the web
+source = "https://agldwg.github.io/data-roles/vocabulary.ttl"
+
 
 [[catalogs.namespaces]]
 # top-level BDR-Dataset namespace

--- a/sources/abis-themes.ttl
+++ b/sources/abis-themes.ttl
@@ -1,57 +1,96 @@
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix cs: <https://linked.data.gov.au/def/abis/vocab-themes> .
-@prefix : <https://linked.data.gov.au/def/abis/vocab-themes/> .
+PREFIX : <https://linked.data.gov.au/def/abis/vocab-themes/>
+PREFIX cs: <https://linked.data.gov.au/def/abis/vocab-themes>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
-cs: a skos:ConceptScheme ;
-    skos:hasTopConcept :feature-types ;
-    skos:hasTopConcept :sampling-types ;
-    skos:hasTopConcept :data-roles ;
-    skos:hasTopConcept :datatypes ;
-    skos:hasTopConcept :procedures ;
-    skos:hasTopConcept :observation-types ;
-    skos:hasTopConcept :observable-properties ;
-    skos:prefLabel "ABIS Themed-Vocabulary Themes"@en;
-    .
+cs:
+    a skos:ConceptScheme ;
+    skos:hasTopConcept
+        :datatypes ,
+        :data-roles ,
+        :feature-types ,
+        :observation-types ,
+        :observable-properties ,
+        :procedures ,
+        :sampling-types ;
+    skos:prefLabel "ABIS Vocabulary Themes"@en;
+    skos:definition "This vocabulary contains themes that vocabularies by data created according to the the Australian Biodiversity Information Standard (ABIS) are categorised with." ;
+    schema:creator <https://linked.data.gov.au/org/dcceew> ;
+    schema:publisher <https://linked.data.gov.au/org/dcceew> ;
+    schema:dateCreated "2024-06-21"^^xsd:date ;
+    schema:dateModified "2025-04-16"^^xsd:date ;
+    schema:license <http://purl.org/NET/rdflicense/cc-by4.0> ;
+    skos:historyNote "Created by the BDR team in 2024 to assist with management of the BDR content" ;
+.
 
-:data-roles a skos:Concept ;
-    skos:prefLabel "ABIS Vocab Theme: Data Roles";
-    skos:definition "Vocabularies with the dcat:theme abis/data-themes:data-roles can be used for prov role attributions on ABIS Datasets."@en;
-    skos:topConceptOf cs: ;
-    .
+<https://linked.data.gov.au/org/dcceew>
+    a schema:Organization ;
+    schema:name "Department of Climate Change, Energy, the Environment and Water, DCCEEW" ;
+    schema:url "https://www.dcceew.gov.au"^^xsd:anyURI ;
+.
 
-:datatypes a skos:Concept ;
-    skos:prefLabel "ABIS Vocab Theme: Data Types";
+:datatypes
+    a skos:Concept ;
+    skos:prefLabel "Data Types";
     skos:definition "Vocabularies with the dcat:theme abis/data-themes:datatypes can be used for Literal Datatypes in ABIS Datasets."@en;
+    rdfs:isDefinedBy cs: ;
+    skos:inScheme cs: ;
     skos:topConceptOf cs: ;
-    .
+.
 
-:feature-types a skos:Concept ;
-    skos:prefLabel "ABIS Vocab Theme: Feature Types";
+:data-roles 
+    a skos:Concept ;
+    skos:prefLabel "Data Roles";
+    skos:definition "Vocabularies with the dcat:theme abis/data-themes:data-roles can be used for prov role attributions on ABIS Datasets."@en;
+    rdfs:isDefinedBy cs: ;
+    skos:inScheme cs: ;
+    skos:topConceptOf cs: ;
+.
+
+:feature-types 
+    a skos:Concept ;
+    skos:prefLabel "Feature Types";
     skos:definition "Vocabularies with the dcat:theme abis/vocab-themes:feature-type can be used where concepts go in the tern:featureType slot"@en;
+    rdfs:isDefinedBy cs: ;
+    skos:inScheme cs: ;
     skos:topConceptOf cs: ;
-    .
+.
 
-:sampling-types a skos:Concept ;
-    skos:prefLabel "ABIS Vocab Theme: Sampling Types";
-    skos:definition "Vocabularies with the dcat:theme abis/vocab-themes:sample-type can be used where concepts go in the tern:samplingType or sdo:additionalType slot on a tern:Sampling or sosa:Sampling."@en;
-    skos:topConceptOf cs: ;
-    .
-
-:observation-types a skos:Concept ;
-    skos:prefLabel "ABIS Vocab Theme: Observation Types";
-    skos:definition "Vocabularies with the dcat:theme abis/vocab-themes:observation-type can be used where concepts go in the tern:observationType or sdo:additionalType slot on a tern:Observation or sosa:Observation."@en;
-    skos:topConceptOf cs: ;
-    .
-
-:procedures a skos:Concept ;
-    skos:prefLabel "ABIS Vocab Theme: Procedures";
-    skos:definition "Vocabularies with the dcat:theme abis/vocab-themes:observation-type can be used where concepts go in the tern:observationType or sdo:additionalType slot on a tern:Observation or sosa:Observation."@en;
-    skos:topConceptOf cs: ;
-    .
-
-:observable-properties a skos:Concept ;
-    skos:prefLabel "ABIS Vocab Theme: Observable Properties";
+:observable-properties 
+    a skos:Concept ;
+    skos:prefLabel "Observable Properties";
     skos:definition "Vocabularies with the dcat:theme abis/vocab-themes:observable-properties can be used where concepts go in observableProperty on a sosa:FeatureOfInterest or observedProperty on sosa:Observation."@en;
+    rdfs:isDefinedBy cs: ;
+    skos:inScheme cs: ;
     skos:topConceptOf cs: ;
-    .
+.
+
+:observation-types
+    a skos:Concept ;
+    skos:prefLabel "Observation Types";
+    skos:definition "Vocabularies with the dcat:theme abis/vocab-themes:observation-type can be used where concepts go in the tern:observationType or sdo:additionalType slot on a tern:Observation or sosa:Observation."@en;
+    rdfs:isDefinedBy cs: ;
+    skos:inScheme cs: ;
+    skos:topConceptOf cs: ;
+.
+
+:procedures
+    a skos:Concept ;
+    skos:prefLabel "Procedures";
+    skos:definition "Vocabularies with the dcat:theme abis/vocab-themes:observation-type can be used where concepts go in the tern:observationType or sdo:additionalType slot on a tern:Observation or sosa:Observation."@en;
+    rdfs:isDefinedBy cs: ;
+    skos:inScheme cs: ;
+    skos:topConceptOf cs: ;
+.
+
+:sampling-types
+    a skos:Concept ;
+    skos:prefLabel "Sampling Types";
+    skos:definition "Vocabularies with the dcat:theme abis/vocab-themes:sample-type can be used where concepts go in the tern:samplingType or sdo:additionalType slot on a tern:Sampling or sosa:Sampling."@en;
+    rdfs:isDefinedBy cs: ;
+    skos:inScheme cs: ;
+    skos:topConceptOf cs: ;
+.


### PR DESCRIPTION
* systematise catalogue naming on type - so far all vocabs
* fold Data Roles into "BDR Vocabs"
    * it doesn't need a whole catalogue all to itself
    * can all all other vocabs required by BDR, as opposed to TERN or ABIS, in "BDR Vocabs"
* make ABIS Themes vocab VocPub valid